### PR TITLE
chore: setup commit hook for dev team

### DIFF
--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const conventionalCommitMessageRegExp = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)/g;
+let exitCode = 0;
+const commitMsgFile = process.argv[2];
+const message = fs.readFileSync(commitMsgFile, 'utf8');
+const isValid = conventionalCommitMessageRegExp.test(message);
+
+if (!isValid) {
+   console.log('Cannot commit: the commit message does not comply with conventional commits standards.');
+   exitCode = 1;
+}
+
+process.exit(exitCode);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "setup:git-hooks": "git config core.hooksPath .githooks",
+    "postinstall": "npm run setup:git-hooks"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "setup:git-hooks": "git config core.hooksPath .githooks",
+    "setup:git-hooks": "git config core.hooksPath .git-hooks",
     "postinstall": "npm run setup:git-hooks"
   },
   "dependencies": {


### PR DESCRIPTION
This enforce the conventional commits rules within the team. The hooks are automatically configured on each machine after running `npm install` thanks to a postinstall script.